### PR TITLE
Fix array_has

### DIFF
--- a/laravel_helpers.js
+++ b/laravel_helpers.js
@@ -176,6 +176,6 @@ function array_fetch (arr,key)
  */
 function array_has (arr,key)
 {
-    return (array_get(arr,key,false)!==false && array_get(arr,key,true)!==true);
+    return !(array_get(arr,key,false)===false && array_get(arr,key,true)===true);
 }
 


### PR DESCRIPTION
I had issues with an array like this where `array_has(schema,'a.b.c')` returned `false`

```js
const schema = {
	a: {
		b: {
			c: true
		}	
	}
}
array_has(schema,'a.b.c') // => true
array_has(schema,'a.b.c.d') // => false
array_has(schema,'a.b') // => true
```
This should fix it.